### PR TITLE
Add Vector3 conversion helpers

### DIFF
--- a/DTpy/mathematics.py
+++ b/DTpy/mathematics.py
@@ -19,6 +19,14 @@ class Vector3:
     def dot(self, other: "Vector3") -> float:
         return sum(a * b for a, b in zip(self, other))
 
+    def to_tuple(self) -> tuple[float, float, float]:
+        """Convert data to a tuple."""
+        return self.x, self.y, self.z
+
+    def to_numpy(self):
+        """Convert data to a numpy array."""
+        return np.array(self.to_tuple())
+
 
 class Tensor3:
     """A 3x3 tensor."""


### PR DESCRIPTION
## Summary
- add `to_tuple` and `to_numpy` methods to `Vector3`

## Testing
- `.venv/bin/python test.py`
- `.venv/bin/python -c "import numpy as np; from DTpy.mathematics import Vector3; v=Vector3(1,2,3); assert v.to_tuple() == (1,2,3); arr=v.to_numpy(); assert isinstance(arr, np.ndarray); np.testing.assert_array_equal(arr, np.array([1,2,3]))"`