### PR TITLE
Fix statistics dataclass instantiation

### DIFF
--- a/DTpy/statistics.py
+++ b/DTpy/statistics.py
@@ -1,8 +1,6 @@
-from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from math import sqrt, acos
 from statistics import mean, median, stdev, variance
-from typing import Any
 
 from .mathematics import Vector3, Tensor3
 
@@ -14,13 +12,8 @@ class TooFewDataPoints(Exception):
         )
 
 
-class DataAnalysis(ABC):
+class DataAnalysis:
     _min_data = 1
-
-    @property
-    @abstractmethod
-    def data(self) -> list[Any]:
-        raise NotImplementedError
 
     @property
     def N(self) -> int:


### PR DESCRIPTION
## Summary
- remove the abstract data property from DataAnalysis so ScalarAnalysis and VectorAnalysis can be instantiated as dataclasses
- drop now-unused ABC-related imports

## Verification
- .venv/bin/python -c "from DTpy.statistics import ScalarAnalysis, VectorAnalysis; from DTpy.mathematics import Vector3; assert ScalarAnalysis([1, 2]).N == 2; assert VectorAnalysis([Vector3(1, 0, 0), Vector3(0, 1, 0)]).N == 2"