### PR TITLE
Stabilize eigenvector ordering

### DIFF
--- a/DTpy/mathematics.py
+++ b/DTpy/mathematics.py
@@ -59,7 +59,7 @@ class Tensor3:
         See <https://en.wikipedia.org/wiki/Eigendecomposition_of_a_matrix>
         """
         eVal, eVec = np.linalg.eig(self.tensor)
-        # the output of linalg.eig is not guaranteed to be sorted
+        # the output of linalg.eig is not guaranteed to be sorted, so we sort it here by eigenvalue
         descending = np.argsort(-eVal, kind="stable")
         eVal = eVal[descending]
         eVec = eVec[:, descending]  # columns are vectors

--- a/DTpy/mathematics.py
+++ b/DTpy/mathematics.py
@@ -60,8 +60,7 @@ class Tensor3:
         """
         eVal, eVec = np.linalg.eig(self.tensor)
         # the output of linalg.eig is not guaranteed to be sorted
-        ascending = np.argsort(eVal)
-        descending = ascending[::-1]
+        descending = np.argsort(-eVal, kind="stable")
         eVal = eVal[descending]
         eVec = eVec[:, descending]  # columns are vectors
         return eVal, eVec

--- a/tests/test_diffusion_tensor.py
+++ b/tests/test_diffusion_tensor.py
@@ -22,6 +22,16 @@ class DiffusionTensorTest(unittest.TestCase):
         np.testing.assert_allclose(np.abs(vectors[1]), [0, 0, 1])
         np.testing.assert_allclose(np.abs(vectors[2]), [1, 0, 0])
 
+    def test_repeated_eigenvalues_keep_eigenvector_order(self):
+        dt = DiffusionTensor([[1, 0, 0], [0, 2, 0], [0, 0, 2]])
+
+        vectors = [np.array(tuple(vector)) for vector in (dt.E1, dt.E2, dt.E3)]
+
+        self.assertEqual(tuple(dt.EigenValues), (2, 2, 1))
+        np.testing.assert_allclose(np.abs(vectors[0]), [0, 1, 0])
+        np.testing.assert_allclose(np.abs(vectors[1]), [0, 0, 1])
+        np.testing.assert_allclose(np.abs(vectors[2]), [1, 0, 0])
+
     def test_scalar_diffusion_metrics(self):
         dt = DiffusionTensor([[3, 0, 0], [0, 2, 0], [0, 0, 1]])
 


### PR DESCRIPTION
## Summary
- use a stable descending eigenvalue sort so repeated eigenvalues keep eigenvector order
- add a regression test for repeated eigenvalues

## Tests
- `.venv/bin/python -m unittest discover -s tests`

## Related

Closes #1 (does not order the eigenvectors in any specific manner, but at least provides stable sorting)